### PR TITLE
Reduce page change interval

### DIFF
--- a/OpenPRs.html
+++ b/OpenPRs.html
@@ -14,7 +14,7 @@
       <p class="loadingWaiter">Loading...</p>
     </div>
     <div class="container-fluid" data-bind="visible: !uninitialised()">
-      <div id="myCarousel" class="carousel slide" data-ride="carousel" data-interval="20000">
+      <div id="myCarousel" class="carousel slide" data-ride="carousel" data-interval="10000">
         <div class="carousel-inner" role="listbox">
           <div class="item active">
             <div class="row">


### PR DESCRIPTION
20 seconds is too long - it takes a whole minute to see the first page again.